### PR TITLE
Add php 7.3 to role php-fpm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ services:
 before_install:
  - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 script:
- - /bin/sh export.sh 7.0.1
+ - /bin/sh export.sh 7.0.3

--- a/derivatives/fpm.yml
+++ b/derivatives/fpm.yml
@@ -5,5 +5,6 @@
   roles:
     - { role: php-fpm, php_version: 5.6 }
     - { role: php-fpm, php_version: 7.0 }
-    - { role: php-fpm, php_version: 7.2 }
     - { role: php-fpm, php_version: 7.1 }
+    - { role: php-fpm, php_version: 7.2 }
+    - { role: php-fpm, php_version: 7.3 }


### PR DESCRIPTION
Working on STEM ce-vm this morning I saw that when you run vagrant up for the fpm container, the folders (and subfolders)
/etc/php/7.0/fpm
/etc/php/7.1/fpm
/etc/php/7.2/fpm

are created, but not for these ones:

/etc/php/7.3/fpm (it is not created)
/etc/php/7.4/fpm (it is not created)

That means I can't install any other php extension inside:

/etc/php/7.3/fpm/conf.d


Also, I have updated the tag version in travis.yml to the 7.0.3, because I saw last version of pmce/* images are using the tag 7.0.2