### PR TITLE
Prefer symlinking over renaming of drush.phar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ services:
 before_install:
  - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 script:
- - /bin/sh export.sh 7.0.3
+ - /bin/sh export.sh 7.0.4

--- a/derivatives/roles/drush/tasks/main.yml
+++ b/derivatives/roles/drush/tasks/main.yml
@@ -3,8 +3,14 @@
 - name: Download Drush installer.
   get_url:
     url: https://github.com/drush-ops/drush/releases/download/8.3.2/drush.phar
-    dest: /usr/local/bin/drush
+    dest: /usr/local/bin/drush.phar
     mode: 0755
+
+- name: Symlink Drush.
+  file:
+    src: /usr/local/bin/drush.phar
+    dest: /usr/local/bin/drush
+    state: link
 
 - name: Trigger drush init tasks.
   command: >


### PR DESCRIPTION
Previously we renamed drush.phar to drush but in certain circumstances
this caused TYPO3\PharStreamWrapper\Exception exceptions when running
drush commands.